### PR TITLE
Exclude kafka-clients from citrus and use 3.9.2 kafka-clients instead

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <camel.version>4.18.1</camel.version>
 
         <citrus.version>4.9.2</citrus.version>
+        <kafka.version>3.9.2</kafka.version>
         <jose4j.version>0.9.6</jose4j.version>
 
         <!-- Versions used inside Kamelets (add them also to the dependencyManagement section and the groovy script below) -->
@@ -88,7 +89,7 @@
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-parent</artifactId>
-                <version>${camel-version}</version>
+                <version>${camel.version}</version>
             </dependency>
 
             <dependency>

--- a/tests/camel-kamelets-itest/pom.xml
+++ b/tests/camel-kamelets-itest/pom.xml
@@ -136,9 +136,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.citrusframework</groupId>
             <artifactId>citrus-kafka</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka-clients</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.citrusframework</groupId>


### PR DESCRIPTION
Exclude kafka-clients from citrus and use 3.9.2 kafka-clients instead