### PR TITLE
JDK25 build support for camel-kamelets

### DIFF
--- a/library/camel-kamelets-crds/pom.xml
+++ b/library/camel-kamelets-crds/pom.xml
@@ -37,8 +37,9 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
 
-    <fabric8-version>7.5.2</fabric8-version>
+    <fabric8-version>7.6.1</fabric8-version>
     <maven-surefire-plugin-version>3.5.0</maven-surefire-plugin-version>
+    <maven-compiler-plugin-version>3.13.0</maven-compiler-plugin-version>
   </properties>
 
   <dependencyManagement>
@@ -76,6 +77,14 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin-version}</version>
+        <configuration>
+          <proc>full</proc>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>java-generator-maven-plugin</artifactId>

--- a/library/kamelets-maven-plugin/pom.xml
+++ b/library/kamelets-maven-plugin/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>4.0.2</version>
+            <version>4.0.3</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <camel.version>4.19.0</camel.version>
 
         <citrus.version>4.9.2</citrus.version>
+        <kafka.version>3.9.2</kafka.version>
         <jose4j.version>0.9.6</jose4j.version>
 
         <!-- Versions used inside Kamelets (add them also to the dependencyManagement section and the groovy script below) -->
@@ -88,7 +89,7 @@
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-parent</artifactId>
-                <version>${camel-version}</version>
+                <version>${camel.version}</version>
             </dependency>
 
             <dependency>

--- a/tests/camel-kamelets-itest/pom.xml
+++ b/tests/camel-kamelets-itest/pom.xml
@@ -136,9 +136,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.citrusframework</groupId>
             <artifactId>citrus-kafka</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka-clients</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.citrusframework</groupId>


### PR DESCRIPTION
Cherry pick over important commits from 4.18.1 camel-kamelets -> 4.19.0 camel-kamelets - we need the JDK 25 build support, kafka and plexus-utils upgrades.