### PR TITLE
Fix Kafka SMT kamelets for CAMEL-23584 header rename

### DIFF
--- a/kamelets/timestamp-router-action.kamelet.yaml
+++ b/kamelets/timestamp-router-action.kamelet.yaml
@@ -46,7 +46,7 @@ spec:
         title: Timestamp Header Name
         description: The name of the header containing a timestamp
         type: string
-        default: "kafka.TIMESTAMP"
+        default: "CamelKafkaTimestamp"
     type: object
   dependencies:
   - "camel:kamelet"

--- a/kamelets/topic-name-matches-filter-action.kamelet.yaml
+++ b/kamelets/topic-name-matches-filter-action.kamelet.yaml
@@ -47,6 +47,6 @@ spec:
       uri: kamelet:source
       steps:
       - filter:
-          simple: "${header[kafka.TOPIC]} !regex '{{regex}}'"
+          simple: "${header[CamelKafkaTopic]} !regex '{{regex}}'"
           steps:
             - stop: {}

--- a/library/camel-kamelets/src/main/resources/kamelets/timestamp-router-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/timestamp-router-action.kamelet.yaml
@@ -46,7 +46,7 @@ spec:
         title: Timestamp Header Name
         description: The name of the header containing a timestamp
         type: string
-        default: "kafka.TIMESTAMP"
+        default: "CamelKafkaTimestamp"
     type: object
   dependencies:
   - "camel:kamelet"

--- a/library/camel-kamelets/src/main/resources/kamelets/topic-name-matches-filter-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/topic-name-matches-filter-action.kamelet.yaml
@@ -47,6 +47,6 @@ spec:
       uri: kamelet:source
       steps:
       - filter:
-          simple: "${header[kafka.TOPIC]} !regex '{{regex}}'"
+          simple: "${header[CamelKafkaTopic]} !regex '{{regex}}'"
           steps:
             - stop: {}


### PR DESCRIPTION
Backport of apache/camel-kamelets#2876 to midstream `camel-kamelets-4.18.1-branch`.

CAMEL-23584 renamed all camel-kafka Exchange header constants from `kafka.*` to `CamelKafka*` prefix, but two kamelet YAML definitions were not updated:

- `topic-name-matches-filter-action.kamelet.yaml`: `${header[kafka.TOPIC]}` → `${header[CamelKafkaTopic]}`
- `timestamp-router-action.kamelet.yaml`: `timestampHeaderName` default `kafka.TIMESTAMP` → `CamelKafkaTimestamp`

Fix verified locally — both TopicNameMatchesFilterActionKameletITCase and TimestampRouterActionKameletITCase pass.

Jira: [CSB-9624](https://redhat.atlassian.net/browse/CSB-9624) / [CSB-9625](https://redhat.atlassian.net/browse/CSB-9625)