### PR TITLE
Fix Kafka SSL kamelets validation and CAMEL-23584 header rename

### DIFF
--- a/kamelets/kafka-batch-ssl-source.kamelet.yaml
+++ b/kamelets/kafka-batch-ssl-source.kamelet.yaml
@@ -1,0 +1,209 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: kafka-batch-ssl-source
+  annotations:
+    camel.apache.org/kamelet.support.level: "Stable"
+    camel.apache.org/catalog.version: "4.18.1-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxOS4wLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiDQoJIHZpZXdCb3g9IjAgMCA1MDAgNTAwIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MDAgNTAwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8ZyBpZD0iWE1MSURfMV8iPg0KCTxwYXRoIGlkPSJYTUxJRF85XyIgZD0iTTMxNC44LDI2OS43Yy0xNC4yLDAtMjcsNi4zLTM1LjcsMTYuMkwyNTYuOCwyNzBjMi40LTYuNSwzLjctMTMuNiwzLjctMjAuOWMwLTcuMi0xLjMtMTQuMS0zLjYtMjAuNg0KCQlsMjIuMy0xNS43YzguNyw5LjksMjEuNCwxNi4xLDM1LjYsMTYuMWMyNi4yLDAsNDcuNi0yMS4zLDQ3LjYtNDcuNnMtMjEuMy00Ny42LTQ3LjYtNDcuNnMtNDcuNiwyMS4zLTQ3LjYsNDcuNg0KCQljMCw0LjcsMC43LDkuMiwyLDEzLjVsLTIyLjMsMTUuN2MtOS4zLTExLjYtMjIuOC0xOS42LTM4LjEtMjIuMXYtMjYuOWMyMS42LTQuNSwzNy44LTIzLjcsMzcuOC00Ni42YzAtMjYuMi0yMS4zLTQ3LjYtNDcuNi00Ny42DQoJCWMtMjYuMiwwLTQ3LjYsMjEuMy00Ny42LDQ3LjZjMCwyMi42LDE1LjgsNDEuNSwzNi45LDQ2LjN2MjcuM2MtMjguOCw1LjEtNTAuOCwzMC4yLTUwLjgsNjAuNWMwLDMwLjQsMjIuMiw1NS43LDUxLjIsNjAuNXYyOC44DQoJCWMtMjEuMyw0LjctMzcuNCwyMy43LTM3LjQsNDYuNGMwLDI2LjIsMjEuMyw0Ny42LDQ3LjYsNDcuNmMyNi4yLDAsNDcuNi0yMS4zLDQ3LjYtNDcuNmMwLTIyLjctMTYtNDEuOC0zNy40LTQ2LjR2LTI4LjgNCgkJYzE1LTIuNSwyOC4yLTEwLjQsMzcuNC0yMS44bDIyLjUsMTUuOWMtMS4yLDQuMy0xLjksOC43LTEuOSwxMy40YzAsMjYuMiwyMS4zLDQ3LjYsNDcuNiw0Ny42czQ3LjYtMjEuMyw0Ny42LTQ3LjYNCgkJQzM2Mi40LDI5MSwzNDEuMSwyNjkuNywzMTQuOCwyNjkuN3ogTTMxNC44LDE1OC40YzEyLjcsMCwyMy4xLDEwLjQsMjMuMSwyMy4xYzAsMTIuNy0xMC4zLDIzLjEtMjMuMSwyMy4xcy0yMy4xLTEwLjQtMjMuMS0yMy4xDQoJCUMyOTEuOCwxNjguOCwzMDIuMSwxNTguNCwzMTQuOCwxNTguNHogTTE3NiwxMTUuMWMwLTEyLjcsMTAuMy0yMy4xLDIzLjEtMjMuMWMxMi43LDAsMjMuMSwxMC40LDIzLjEsMjMuMQ0KCQljMCwxMi43LTEwLjMsMjMuMS0yMy4xLDIzLjFDMTg2LjMsMTM4LjIsMTc2LDEyNy44LDE3NiwxMTUuMXogTTIyMi4xLDM4NC45YzAsMTIuNy0xMC4zLDIzLjEtMjMuMSwyMy4xDQoJCWMtMTIuNywwLTIzLjEtMTAuNC0yMy4xLTIzLjFjMC0xMi43LDEwLjMtMjMuMSwyMy4xLTIzLjFDMjExLjgsMzYxLjgsMjIyLjEsMzcyLjIsMjIyLjEsMzg0Ljl6IE0xOTkuMSwyODEuMw0KCQljLTE3LjcsMC0zMi4yLTE0LjQtMzIuMi0zMi4yYzAtMTcuNywxNC40LTMyLjIsMzIuMi0zMi4yYzE3LjcsMCwzMi4yLDE0LjQsMzIuMiwzMi4yQzIzMS4yLDI2Ni45LDIxNi44LDI4MS4zLDE5OS4xLDI4MS4zeg0KCQkgTTMxNC44LDM0MC4zYy0xMi43LDAtMjMuMS0xMC40LTIzLjEtMjMuMWMwLTEyLjcsMTAuMy0yMy4xLDIzLjEtMjMuMXMyMy4xLDEwLjQsMjMuMSwyMy4xQzMzNy45LDMzMCwzMjcuNSwzNDAuMywzMTQuOCwzNDAuM3oiLz4NCjwvZz4NCjwvc3ZnPg0K"
+    camel.apache.org/provider: "Red Hat"
+    camel.apache.org/kamelet.group: "Kafka"
+    camel.apache.org/kamelet.namespace: "Kafka"
+  labels:
+    camel.apache.org/kamelet.type: "source"
+spec:
+  definition:
+    title: "Kafka Batch SSL Source"
+    description: |-
+      Receive data from Kafka topics in batch with SSL/TLS support and commit them manually through KafkaManualCommit or automatically.
+    required:
+      - topic
+      - bootstrapServers
+      - sslTruststoreLocation
+      - sslKeyPassword
+    type: object
+    properties:
+      topic:
+        title: Topic Names
+        description: Comma separated list of Kafka topic names
+        type: string
+        x-descriptors:
+          - urn:keda:metadata:topic
+          - urn:keda:required
+      bootstrapServers:
+        title: Bootstrap Servers
+        description: Comma separated list of Kafka Broker URLs
+        type: string
+        x-descriptors:
+          - urn:keda:metadata:bootstrapServers
+          - urn:keda:required
+      securityProtocol:
+        title: Security Protocol
+        description: Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT, SASL_SSL and SSL are supported
+        type: string
+        default: SSL
+      saslMechanism:
+        title: SASL Mechanism
+        description: The Simple Authentication and Security Layer (SASL) Mechanism used.
+        type: string
+        default: GSSAPI
+      autoCommitEnable:
+        title: Auto Commit Enable
+        description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
+        type: boolean
+        default: true
+      allowManualCommit:
+        title: Allow Manual Commit
+        description: Whether to allow doing manual commits
+        type: boolean
+        default: false
+      pollOnError:
+        title: Poll On Error Behavior
+        description: What to do if kafka threw an exception while polling for new messages. There are 5 enums and the value can be one of DISCARD, ERROR_HANDLER, RECONNECT, RETRY, STOP
+        type: string
+        default: "ERROR_HANDLER"
+      autoOffsetReset:
+        title: Auto Offset Reset
+        description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
+        type: string
+        default: "latest"
+        x-descriptors:
+          - urn:keda:metadata:offsetResetPolicy
+      consumerGroup:
+        title: Consumer Group
+        description: A string that uniquely identifies the group of consumers to which this source belongs
+        type: string
+        example: "my-group-id"
+        x-descriptors:
+          - urn:keda:metadata:consumerGroup
+          - urn:keda:required
+      deserializeHeaders:
+        title: Automatically Deserialize Headers
+        description: When enabled the Kamelet source will deserialize all message headers to String representation.
+        type: boolean
+        default: true
+      sslKeyPassword:
+        description: The password of the private key in the key store file.
+        title: SSL Key Password
+        type: string
+        format: password
+        x-descriptors:
+          - urn:camel:group:credentials
+          - urn:keda:authentication:password
+          - urn:keda:required
+      sslKeystorePassword:
+        description: The store password for the key store file.This is optional for client and only needed if ssl.keystore.location is configured.
+        title: SSL Keystore Password
+        type: string
+        format: password
+        x-descriptors:
+          - urn:camel:group:credentials
+          - urn:keda:authentication:password
+      sslEndpointAlgorithm:
+        description: The endpoint identification algorithm to validate server hostname using server certificate. Use none or false to disable server hostname verification.
+        title: SSL Endpoint Algorithm
+        type: string
+        default: https
+      sslProtocol:
+        description: The SSL protocol used to generate the SSLContext. Default setting is TLS, which is fine for most cases. Allowed values in recent JVMs are TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.
+        title: SSL Protocol
+        type: string
+        default: TLSv1.2
+      sslKeystoreLocation:
+        description: The location of the key store file. This is optional for client and can be used for two-way authentication for client.
+        title: SSL Keystore Location
+        type: string
+      sslTruststoreLocation:
+        description: The location of the trust store file.
+        title: SSL Truststore Location
+        type: string
+      sslEnabledProtocols:
+        description:   The list of protocols enabled for SSL connections. TLSv1.2, TLSv1.1 and TLSv1 are enabled by default.
+        title: SSL Enabled Protocols
+        type: string
+        default: TLSv1.2,TLSv1.1,TLSv1
+      saslJaasConfig:
+        description: Java Authentication and Authorization Service (JAAS) for Simple Authentication and Security Layer (SASL) configuration.
+        title: JAAS Configuration
+        type: string
+      batchSize:
+        title: Batch Dimension
+        description: The maximum number of records returned in a single call to poll()
+        type: int
+        default: 500
+      pollTimeout:
+        title: Poll Timeout Interval
+        description: The timeout used when polling the KafkaConsumer
+        type: int
+        default: 5000
+      maxPollIntervalMs:
+        title: Max Poll Interval
+        description: The maximum delay between invocations of poll() when using consumer group management
+        type: int
+      batchingIntervalMs:
+        title: Batching Interval
+        description: In consumer batching mode, then this option is specifying a time in millis, to trigger batch completion eager when the current batch size has not reached the maximum size defined by maxPollRecords. Notice the trigger is not exact at the given interval, as this can only happen between kafka polls (see pollTimeoutMs option).
+        type: int
+      topicIsPattern:
+        title: Topic Is Pattern
+        description: Whether the topic is a pattern (regular expression). This can be used to subscribe to dynamic number of topics matching the pattern.
+        type: boolean
+        default: false
+  dependencies:
+    - "camel:core"
+    - "camel:kafka"
+    - "camel:kamelet"
+  template:
+    beans:
+      - name: manualCommitFactory
+        type: "#class:org.apache.camel.component.kafka.consumer.DefaultKafkaManualCommitFactory"
+      - name: kafkaHeaderDeserializer
+        type: "#class:org.apache.camel.component.kafka.KafkaHeaderDeserializer"
+        properties:
+          enabled: '{{deserializeHeaders}}'
+    from:
+      uri: "kafka:{{topic}}"
+      parameters:
+        brokers: "{{bootstrapServers}}"
+        securityProtocol: "{{securityProtocol}}"
+        sslKeystoreLocation: "{{sslKeystoreLocation}}"
+        sslKeyPassword: "{{sslKeyPassword}}"
+        sslKeystorePassword: "{{sslKeystorePassword}}"
+        sslTruststoreLocation: "{{sslTruststoreLocation}}"
+        sslProtocol: "{{sslProtocol}}"
+        sslEnabledProtocols: "{{sslEnabledProtocols}}"
+        sslEndpointAlgorithm: "{{sslEndpointAlgorithm}}"
+        saslMechanism: "{{saslMechanism}}"
+        groupId: "{{?consumerGroup}}"
+        autoOffsetReset: "{{autoOffsetReset}}"
+        pollOnError: "{{pollOnError}}"
+        allowManualCommit: "{{allowManualCommit}}"
+        autoCommitEnable: "{{autoCommitEnable}}"
+        saslJaasConfig: "{{?saslJaasConfig}}"
+        maxPollRecords: "{{batchSize}}"
+        pollTimeoutMs: "{{pollTimeout}}"
+        maxPollIntervalMs: "{{?maxPollIntervalMs}}"
+        batchingIntervalMs: "{{?batchingIntervalMs}}"
+        batching: true
+        kafkaManualCommitFactory: "#bean:{{manualCommitFactory}}"
+        topicIsPattern: "{{topicIsPattern}}"
+      steps:
+        - process:
+            ref: "{{kafkaHeaderDeserializer}}"
+        - to: "kamelet:sink"

--- a/kamelets/kafka-ssl-sink.kamelet.yaml
+++ b/kamelets/kafka-ssl-sink.kamelet.yaml
@@ -17,98 +17,114 @@
 apiVersion: camel.apache.org/v1
 kind: Kamelet
 metadata:
-  name: kafka-sink
+  name: kafka-ssl-sink
   annotations:
     camel.apache.org/kamelet.support.level: "Stable"
     camel.apache.org/catalog.version: "4.18.1-SNAPSHOT"
     camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxOS4wLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiDQoJIHZpZXdCb3g9IjAgMCA1MDAgNTAwIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MDAgNTAwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8ZyBpZD0iWE1MSURfMV8iPg0KCTxwYXRoIGlkPSJYTUxJRF85XyIgZD0iTTMxNC44LDI2OS43Yy0xNC4yLDAtMjcsNi4zLTM1LjcsMTYuMkwyNTYuOCwyNzBjMi40LTYuNSwzLjctMTMuNiwzLjctMjAuOWMwLTcuMi0xLjMtMTQuMS0zLjYtMjAuNg0KCQlsMjIuMy0xNS43YzguNyw5LjksMjEuNCwxNi4xLDM1LjYsMTYuMWMyNi4yLDAsNDcuNi0yMS4zLDQ3LjYtNDcuNnMtMjEuMy00Ny42LTQ3LjYtNDcuNnMtNDcuNiwyMS4zLTQ3LjYsNDcuNg0KCQljMCw0LjcsMC43LDkuMiwyLDEzLjVsLTIyLjMsMTUuN2MtOS4zLTExLjYtMjIuOC0xOS42LTM4LjEtMjIuMXYtMjYuOWMyMS42LTQuNSwzNy44LTIzLjcsMzcuOC00Ni42YzAtMjYuMi0yMS4zLTQ3LjYtNDcuNi00Ny42DQoJCWMtMjYuMiwwLTQ3LjYsMjEuMy00Ny42LDQ3LjZjMCwyMi42LDE1LjgsNDEuNSwzNi45LDQ2LjN2MjcuM2MtMjguOCw1LjEtNTAuOCwzMC4yLTUwLjgsNjAuNWMwLDMwLjQsMjIuMiw1NS43LDUxLjIsNjAuNXYyOC44DQoJCWMtMjEuMyw0LjctMzcuNCwyMy43LTM3LjQsNDYuNGMwLDI2LjIsMjEuMyw0Ny42LDQ3LjYsNDcuNmMyNi4yLDAsNDcuNi0yMS4zLDQ3LjYtNDcuNmMwLTIyLjctMTYtNDEuOC0zNy40LTQ2LjR2LTI4LjgNCgkJYzE1LTIuNSwyOC4yLTEwLjQsMzcuNC0yMS44bDIyLjUsMTUuOWMtMS4yLDQuMy0xLjksOC43LTEuOSwxMy40YzAsMjYuMiwyMS4zLDQ3LjYsNDcuNiw0Ny42czQ3LjYtMjEuMyw0Ny42LTQ3LjYNCgkJQzM2Mi40LDI5MSwzNDEuMSwyNjkuNywzMTQuOCwyNjkuN3ogTTMxNC44LDE1OC40YzEyLjcsMCwyMy4xLDEwLjQsMjMuMSwyMy4xYzAsMTIuNy0xMC4zLDIzLjEtMjMuMSwyMy4xcy0yMy4xLTEwLjQtMjMuMS0yMy4xDQoJCUMyOTEuOCwxNjguOCwzMDIuMSwxNTguNCwzMTQuOCwxNTguNHogTTE3NiwxMTUuMWMwLTEyLjcsMTAuMy0yMy4xLDIzLjEtMjMuMWMxMi43LDAsMjMuMSwxMC40LDIzLjEsMjMuMQ0KCQljMCwxMi43LTEwLjMsMjMuMS0yMy4xLDIzLjFDMTg2LjMsMTM4LjIsMTc2LDEyNy44LDE3NiwxMTUuMXogTTIyMi4xLDM4NC45YzAsMTIuNy0xMC4zLDIzLjEtMjMuMSwyMy4xDQoJCWMtMTIuNywwLTIzLjEtMTAuNC0yMy4xLTIzLjFjMC0xMi43LDEwLjMtMjMuMSwyMy4xLTIzLjFDMjExLjgsMzYxLjgsMjIyLjEsMzcyLjIsMjIyLjEsMzg0Ljl6IE0xOTkuMSwyODEuMw0KCQljLTE3LjcsMC0zMi4yLTE0LjQtMzIuMi0zMi4yYzAtMTcuNywxNC40LTMyLjIsMzIuMi0zMi4yYzE3LjcsMCwzMi4yLDE0LjQsMzIuMiwzMi4yQzIzMS4yLDI2Ni45LDIxNi44LDI4MS4zLDE5OS4xLDI4MS4zeg0KCQkgTTMxNC44LDM0MC4zYy0xMi43LDAtMjMuMS0xMC40LTIzLjEtMjMuMWMwLTEyLjcsMTAuMy0yMy4xLDIzLjEtMjMuMXMyMy4xLDEwLjQsMjMuMSwyMy4xQzMzNy45LDMzMCwzMjcuNSwzNDAuMywzMTQuOCwzNDAuM3oiLz4NCjwvZz4NCjwvc3ZnPg0K"
-    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/provider: "Red Hat"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
   labels:
     camel.apache.org/kamelet.type: "sink"
 spec:
   definition:
-    title: "Kafka Sink"
-    description: Send data to Kafka topics.
+    description: |-
+      Send data to Kafka topics wit TLS/SSL support.
+
+      The Kamelet is able to understand the following headers to be set:
+
+      - `key` / `ce-key`: as message key
+
+      - `partition-key` / `ce-partitionkey`: as message partition key
+
+      Both the headers are optional.
     required:
       - topic
       - bootstrapServers
-    type: object
+      - sslKeystoreLocation
+      - sslKeystorePassword
+      - sslTruststoreLocation
+      - sslTruststorePassword
+      - sslKeyPassword
     properties:
-      topic:
-        title: Topic Names
-        description: Comma separated list of Kafka topic names
-        type: string
       bootstrapServers:
-        title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
+        title: Brokers
         type: string
-      saslAuthType:
-        title: Authentication Type
-        description: Authentication type to use. Use NONE for no authentication, PLAIN or SCRAM_SHA_256/SCRAM_SHA_512 for username/password, SSL for certificate-based, OAUTH for OAuth 2.0, AWS_MSK_IAM for MSK, or KERBEROS for Kerberos.
-        type: string
-        default: NONE
-        enum: ["NONE", "PLAIN", "SCRAM_SHA_256", "SCRAM_SHA_512", "SSL", "OAUTH", "AWS_MSK_IAM", "KERBEROS"]
-      saslUsername:
-        title: Username
-        description: Username for SASL authentication. Required when saslAuthType is PLAIN, SCRAM_SHA_256, or SCRAM_SHA_512.
-        type: string
-        x-descriptors:
-          - urn:camel:group:credentials
-      saslPassword:
-        title: Password
-        description: Password for SASL authentication. Required when saslAuthType is PLAIN, SCRAM_SHA_256, or SCRAM_SHA_512.
-        type: string
-        format: password
-        x-descriptors:
-          - urn:camel:group:credentials
-      oauthClientId:
-        title: OAuth Client ID
-        description: OAuth client ID. Required when saslAuthType is OAUTH.
-        type: string
-      oauthClientSecret:
-        title: OAuth Client Secret
-        description: OAuth client secret. Required when saslAuthType is OAUTH.
-        type: string
-        format: password
-        x-descriptors:
-          - urn:camel:group:credentials
-      oauthTokenEndpointUri:
-        title: OAuth Token Endpoint
-        description: OAuth token endpoint URI. Required when saslAuthType is OAUTH.
-        type: string
-      oauthScope:
-        title: OAuth Scope
-        description: OAuth scope. Optional when saslAuthType is OAUTH.
-        type: string
-      sslTruststoreLocation:
-        title: SSL Truststore Location
-        description: The location of the trust store file.
-        type: string
-      sslTruststorePassword:
-        title: SSL Truststore Password
-        description: The password for the trust store file.
-        type: string
-        format: password
-        x-descriptors:
-          - urn:camel:group:credentials
       sslKeystoreLocation:
+        description: >-
+          The location of the key store file. This is optional for client and
+          can be used for two-way authentication for client.
         title: SSL Keystore Location
-        description: The location of the key store file. Used for mTLS authentication.
+        type: string
+      sslProtocol:
+        default: TLSv1.2
+        description: >-
+          The SSL protocol used to generate the SSLContext. Default setting is
+          TLS, which is fine for most cases. Allowed values in recent JVMs are
+          TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 may be supported in
+          older JVMs, but their usage is discouraged due to known security
+          vulnerabilities.
+        title: SSL Protocol
+        type: string
+      saslMechanism:
+        title: SASL Mechanism
+        description: The Simple Authentication and Security Layer (SASL) Mechanism used.
+        type: string
+        default: GSSAPI
+      sslEnabledProtocols:
+        default: TLSv1.2,TLSv1.1,TLSv1
+        description: >-
+          The list of protocols enabled for SSL connections. TLSv1.2, TLSv1.1
+          and TLSv1 are enabled by default.
+        title: SSL Enabled Protocols
         type: string
       sslKeystorePassword:
+        description: >-
+          The store password for the key store file.This is optional for client
+          and only needed if ssl.keystore.location is configured.
         title: SSL Keystore Password
-        description: The password for the key store file.
+        type: string
+        format: password
+        x-descriptors:
+          - urn:camel:group:credentials
+      sslTruststoreLocation:
+        description: The location of the trust store file.
+        title: SSL Truststore Location
+        type: string
+      sslTruststorePassword:
+        description: The store password for the trust store file.
+        title: SSL Truststore Password
         type: string
         format: password
         x-descriptors:
           - urn:camel:group:credentials
       sslKeyPassword:
-        title: SSL Key Password
         description: The password of the private key in the key store file.
+        title: SSL Key Password
         type: string
         format: password
+        x-descriptors:
+          - urn:camel:group:credentials
+      sslEndpointAlgorithm:
+        description: The endpoint identification algorithm to validate server hostname using server certificate. Use none or false to disable server hostname verification.
+        title: SSL Endpoint Algorithm
+        type: string
+        default: https
+      topic:
+        description: Comma separated list of Kafka topic names
+        title: Topic Names
+        type: string
+      securityProtocol:
+        default: SSL
+        description: >-
+          Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT,
+          SASL_SSL and SSL are supported
+        title: Security Protocol
+        type: string
+    title: Kafka SSL Sink
+    type: object
   dependencies:
     - "camel:core"
     - "camel:kafka"
@@ -117,43 +133,41 @@ spec:
     from:
       uri: "kamelet:source"
       steps:
-      - choice:
-          when:
-          - simple: "${header[key]}"
-            steps:
-            - setHeader:
-                name: CamelKafkaKey
-                simple: "${header[key]}"
-          - simple: "${header[ce-key]}"
-            steps:
-            - setHeader:
-                name: CamelKafkaKey
-                simple: "${header[ce-key]}"
-      - choice:
-          when:
-          - simple: "${header[partition-key]}"
-            steps:
-            - setHeader:
-                name: CamelKafkaPartitionKey
-                simple: "${header[partition-key]}"
-          - simple: "${header[ce-partitionkey]}"
-            steps:
-            - setHeader:
-                name: CamelKafkaPartitionKey
-                simple: "${header[ce-partitionkey]}"
-      - to:
-          uri: "kafka:{{topic}}"
-          parameters:
-            brokers: "{{bootstrapServers}}"
-            saslAuthType: "{{saslAuthType}}"
-            saslUsername: "{{?saslUsername}}"
-            saslPassword: "{{?saslPassword}}"
-            oauthClientId: "{{?oauthClientId}}"
-            oauthClientSecret: "{{?oauthClientSecret}}"
-            oauthTokenEndpointUri: "{{?oauthTokenEndpointUri}}"
-            oauthScope: "{{?oauthScope}}"
-            sslTruststoreLocation: "{{?sslTruststoreLocation}}"
-            sslTruststorePassword: "{{?sslTruststorePassword}}"
-            sslKeystoreLocation: "{{?sslKeystoreLocation}}"
-            sslKeystorePassword: "{{?sslKeystorePassword}}"
-            sslKeyPassword: "{{?sslKeyPassword}}"
+        - choice:
+            when:
+              - simple: ${header[key]}
+                steps:
+                  - setHeader:
+                      name: CamelKafkaKey
+                      simple: ${header[key]}
+              - simple: ${header[ce-key]}
+                steps:
+                  - setHeader:
+                      name: CamelKafkaKey
+                      simple: ${header[ce-key]}
+        - choice:
+            when:
+              - simple: ${header[partition-key]}
+                steps:
+                  - setHeader:
+                      name: CamelKafkaPartitionKey
+                      simple: ${header[partition-key]}
+              - simple: ${header[ce-partitionkey]}
+                steps:
+                  - setHeader:
+                      name: CamelKafkaPartitionKey
+                      simple: ${header[ce-partitionkey]}
+        - to:
+            uri: "kafka:{{topic}}"
+            parameters:
+              brokers: "{{bootstrapServers}}"
+              securityProtocol: "{{securityProtocol}}"
+              sslKeystoreLocation: "{{sslKeystoreLocation}}"
+              sslKeyPassword: "{{sslKeyPassword}}"
+              sslKeystorePassword: "{{sslKeystorePassword}}"
+              sslTruststoreLocation: "{{sslTruststoreLocation}}"
+              sslTruststorePassword: "{{sslTruststorePassword}}"
+              sslProtocol: "{{sslProtocol}}"
+              sslEnabledProtocols: "{{sslEnabledProtocols}}"
+              sslEndpointAlgorithm: "{{sslEndpointAlgorithm}}"
+              saslMechanism: "{{saslMechanism}}"

--- a/kamelets/kafka-ssl-source.kamelet.yaml
+++ b/kamelets/kafka-ssl-source.kamelet.yaml
@@ -1,0 +1,193 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: kafka-ssl-source
+  annotations:
+    camel.apache.org/kamelet.support.level: "Stable"
+    camel.apache.org/catalog.version: "4.18.1-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxOS4wLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiDQoJIHZpZXdCb3g9IjAgMCA1MDAgNTAwIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MDAgNTAwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8ZyBpZD0iWE1MSURfMV8iPg0KCTxwYXRoIGlkPSJYTUxJRF85XyIgZD0iTTMxNC44LDI2OS43Yy0xNC4yLDAtMjcsNi4zLTM1LjcsMTYuMkwyNTYuOCwyNzBjMi40LTYuNSwzLjctMTMuNiwzLjctMjAuOWMwLTcuMi0xLjMtMTQuMS0zLjYtMjAuNg0KCQlsMjIuMy0xNS43YzguNyw5LjksMjEuNCwxNi4xLDM1LjYsMTYuMWMyNi4yLDAsNDcuNi0yMS4zLDQ3LjYtNDcuNnMtMjEuMy00Ny42LTQ3LjYtNDcuNnMtNDcuNiwyMS4zLTQ3LjYsNDcuNg0KCQljMCw0LjcsMC43LDkuMiwyLDEzLjVsLTIyLjMsMTUuN2MtOS4zLTExLjYtMjIuOC0xOS42LTM4LjEtMjIuMXYtMjYuOWMyMS42LTQuNSwzNy44LTIzLjcsMzcuOC00Ni42YzAtMjYuMi0yMS4zLTQ3LjYtNDcuNi00Ny42DQoJCWMtMjYuMiwwLTQ3LjYsMjEuMy00Ny42LDQ3LjZjMCwyMi42LDE1LjgsNDEuNSwzNi45LDQ2LjN2MjcuM2MtMjguOCw1LjEtNTAuOCwzMC4yLTUwLjgsNjAuNWMwLDMwLjQsMjIuMiw1NS43LDUxLjIsNjAuNXYyOC44DQoJCWMtMjEuMyw0LjctMzcuNCwyMy43LTM3LjQsNDYuNGMwLDI2LjIsMjEuMyw0Ny42LDQ3LjYsNDcuNmMyNi4yLDAsNDcuNi0yMS4zLDQ3LjYtNDcuNmMwLTIyLjctMTYtNDEuOC0zNy40LTQ2LjR2LTI4LjgNCgkJYzE1LTIuNSwyOC4yLTEwLjQsMzcuNC0yMS44bDIyLjUsMTUuOWMtMS4yLDQuMy0xLjksOC43LTEuOSwxMy40YzAsMjYuMiwyMS4zLDQ3LjYsNDcuNiw0Ny42czQ3LjYtMjEuMyw0Ny42LTQ3LjYNCgkJQzM2Mi40LDI5MSwzNDEuMSwyNjkuNywzMTQuOCwyNjkuN3ogTTMxNC44LDE1OC40YzEyLjcsMCwyMy4xLDEwLjQsMjMuMSwyMy4xYzAsMTIuNy0xMC4zLDIzLjEtMjMuMSwyMy4xcy0yMy4xLTEwLjQtMjMuMS0yMy4xDQoJCUMyOTEuOCwxNjguOCwzMDIuMSwxNTguNCwzMTQuOCwxNTguNHogTTE3NiwxMTUuMWMwLTEyLjcsMTAuMy0yMy4xLDIzLjEtMjMuMWMxMi43LDAsMjMuMSwxMC40LDIzLjEsMjMuMQ0KCQljMCwxMi43LTEwLjMsMjMuMS0yMy4xLDIzLjFDMTg2LjMsMTM4LjIsMTc2LDEyNy44LDE3NiwxMTUuMXogTTIyMi4xLDM4NC45YzAsMTIuNy0xMC4zLDIzLjEtMjMuMSwyMy4xDQoJCWMtMTIuNywwLTIzLjEtMTAuNC0yMy4xLTIzLjFjMC0xMi43LDEwLjMtMjMuMSwyMy4xLTIzLjFDMjExLjgsMzYxLjgsMjIyLjEsMzcyLjIsMjIyLjEsMzg0Ljl6IE0xOTkuMSwyODEuMw0KCQljLTE3LjcsMC0zMi4yLTE0LjQtMzIuMi0zMi4yYzAtMTcuNywxNC40LTMyLjIsMzIuMi0zMi4yYzE3LjcsMCwzMi4yLDE0LjQsMzIuMiwzMi4yQzIzMS4yLDI2Ni45LDIxNi44LDI4MS4zLDE5OS4xLDI4MS4zeg0KCQkgTTMxNC44LDM0MC4zYy0xMi43LDAtMjMuMS0xMC40LTIzLjEtMjMuMWMwLTEyLjcsMTAuMy0yMy4xLDIzLjEtMjMuMXMyMy4xLDEwLjQsMjMuMSwyMy4xQzMzNy45LDMzMCwzMjcuNSwzNDAuMywzMTQuOCwzNDAuM3oiLz4NCjwvZz4NCjwvc3ZnPg0K"
+    camel.apache.org/provider: "Red Hat"
+    camel.apache.org/kamelet.group: "Kafka"
+    camel.apache.org/kamelet.namespace: "Kafka"
+  labels:
+    camel.apache.org/kamelet.type: "source"
+spec:
+  definition:
+    title: "Kafka SSL Source"
+    description: |-
+      Receive data from Kafka topics with SSL/TLS support
+    required:
+      - topic
+      - bootstrapServers
+      - sslTruststoreLocation
+      - sslTruststorePassword
+      - sslKeyPassword
+    type: object
+    properties:
+      topic:
+        title: Topic Names
+        description: Comma separated list of Kafka topic names
+        type: string
+        x-descriptors:
+          - urn:keda:metadata:topic
+          - urn:keda:required
+      bootstrapServers:
+        title: Bootstrap Servers
+        description: Comma separated list of Kafka Broker URLs
+        type: string
+        x-descriptors:
+          - urn:keda:metadata:bootstrapServers
+          - urn:keda:required
+      securityProtocol:
+        title: Security Protocol
+        description: Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT, SASL_SSL and SSL are supported
+        type: string
+        default: SSL
+      saslMechanism:
+        title: SASL Mechanism
+        description: The Simple Authentication and Security Layer (SASL) Mechanism used.
+        type: string
+        default: GSSAPI
+      autoCommitEnable:
+        title: Auto Commit Enable
+        description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
+        type: boolean
+        default: true
+      allowManualCommit:
+        title: Allow Manual Commit
+        description: Whether to allow doing manual commits
+        type: boolean
+        default: false
+      pollOnError:
+        title: Poll On Error Behavior
+        description: What to do if kafka threw an exception while polling for new messages. There are 5 enums and the value can be one of DISCARD, ERROR_HANDLER, RECONNECT, RETRY, STOP
+        type: string
+        default: "ERROR_HANDLER"
+      autoOffsetReset:
+        title: Auto Offset Reset
+        description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
+        type: string
+        default: "latest"
+        x-descriptors:
+          - urn:keda:metadata:offsetResetPolicy
+      consumerGroup:
+        title: Consumer Group
+        description: A string that uniquely identifies the group of consumers to which this source belongs
+        type: string
+        example: "my-group-id"
+        x-descriptors:
+          - urn:keda:metadata:consumerGroup
+          - urn:keda:required
+      deserializeHeaders:
+        title: Automatically Deserialize Headers
+        description: When enabled the Kamelet source will deserialize all message headers to String representation.
+        type: boolean
+        default: true
+      sslKeyPassword:
+        description: The password of the private key in the key store file.
+        title: SSL Key Password
+        type: string
+        format: password
+        x-descriptors:
+          - urn:camel:group:credentials
+          - urn:keda:authentication:password
+          - urn:keda:required
+      sslKeystorePassword:
+        description: The store password for the key store file.This is optional for client and only needed if ssl.keystore.location is configured.
+        title: SSL Keystore Password
+        type: string
+        format: password
+        x-descriptors:
+          - urn:camel:group:credentials
+          - urn:keda:authentication:password
+      sslEndpointAlgorithm:
+        description: The endpoint identification algorithm to validate server hostname using server certificate. Use none or false to disable server hostname verification.
+        title: SSL Endpoint Algorithm
+        type: string
+        default: https
+      sslProtocol:
+        description: The SSL protocol used to generate the SSLContext. Default setting is TLS, which is fine for most cases. Allowed values in recent JVMs are TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.
+        title: SSL Protocol
+        type: string
+        default: TLSv1.2
+      sslKeystoreLocation:
+        description: The location of the key store file. This is optional for client and can be used for two-way authentication for client.
+        title: SSL Keystore Location
+        type: string
+      sslTruststoreLocation:
+        description: The location of the trust store file.
+        title: SSL Truststore Location
+        type: string
+      sslTruststorePassword:
+        description: The store password for the trust store file.
+        title: SSL Truststore Password
+        type: string
+        format: password
+        x-descriptors:
+          - urn:camel:group:credentials
+          - urn:keda:authentication:password
+      sslEnabledProtocols:
+        description:   The list of protocols enabled for SSL connections. TLSv1.2, TLSv1.1 and TLSv1 are enabled by default.
+        title: SSL Enabled Protocols
+        type: string
+        default: TLSv1.2,TLSv1.1,TLSv1
+      saslJaasConfig:
+        description: Java Authentication and Authorization Service (JAAS) for Simple Authentication and Security Layer (SASL) configuration.
+        title: JAAS Configuration
+        type: string
+      topicIsPattern:
+        title: Topic Is Pattern
+        description: Whether the topic is a pattern (regular expression). This can be used to subscribe to dynamic number of topics matching the pattern.
+        type: boolean
+        default: false
+  dependencies:
+    - "camel:core"
+    - "camel:kafka"
+    - "camel:kamelet"
+  template:
+    beans:
+      - name: kafkaHeaderDeserializer
+        type: "#class:org.apache.camel.component.kafka.KafkaHeaderDeserializer"
+        properties:
+          enabled: '{{deserializeHeaders}}'
+    from:
+      uri: "kafka:{{topic}}"
+      parameters:
+        brokers: "{{bootstrapServers}}"
+        securityProtocol: "{{securityProtocol}}"
+        sslKeystoreLocation: "{{sslKeystoreLocation}}"
+        sslKeyPassword: "{{sslKeyPassword}}"
+        sslKeystorePassword: "{{sslKeystorePassword}}"
+        sslTruststoreLocation: "{{sslTruststoreLocation}}"
+        sslTruststorePassword: "{{sslTruststorePassword}}"
+        sslProtocol: "{{sslProtocol}}"
+        sslEnabledProtocols: "{{sslEnabledProtocols}}"
+        sslEndpointAlgorithm: "{{sslEndpointAlgorithm}}"
+        saslMechanism: "{{saslMechanism}}"
+        groupId: "{{?consumerGroup}}"
+        autoOffsetReset: "{{autoOffsetReset}}"
+        pollOnError: "{{pollOnError}}"
+        allowManualCommit: "{{allowManualCommit}}"
+        autoCommitEnable: "{{autoCommitEnable}}"
+        saslJaasConfig: "{{?saslJaasConfig}}"
+        topicIsPattern: "{{topicIsPattern}}"
+      steps:
+        - process:
+            ref: "{{kafkaHeaderDeserializer}}"
+        - to: "kamelet:sink"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-batch-ssl-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-batch-ssl-source.kamelet.yaml
@@ -1,0 +1,209 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: kafka-batch-ssl-source
+  annotations:
+    camel.apache.org/kamelet.support.level: "Stable"
+    camel.apache.org/catalog.version: "4.18.1-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxOS4wLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiDQoJIHZpZXdCb3g9IjAgMCA1MDAgNTAwIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MDAgNTAwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8ZyBpZD0iWE1MSURfMV8iPg0KCTxwYXRoIGlkPSJYTUxJRF85XyIgZD0iTTMxNC44LDI2OS43Yy0xNC4yLDAtMjcsNi4zLTM1LjcsMTYuMkwyNTYuOCwyNzBjMi40LTYuNSwzLjctMTMuNiwzLjctMjAuOWMwLTcuMi0xLjMtMTQuMS0zLjYtMjAuNg0KCQlsMjIuMy0xNS43YzguNyw5LjksMjEuNCwxNi4xLDM1LjYsMTYuMWMyNi4yLDAsNDcuNi0yMS4zLDQ3LjYtNDcuNnMtMjEuMy00Ny42LTQ3LjYtNDcuNnMtNDcuNiwyMS4zLTQ3LjYsNDcuNg0KCQljMCw0LjcsMC43LDkuMiwyLDEzLjVsLTIyLjMsMTUuN2MtOS4zLTExLjYtMjIuOC0xOS42LTM4LjEtMjIuMXYtMjYuOWMyMS42LTQuNSwzNy44LTIzLjcsMzcuOC00Ni42YzAtMjYuMi0yMS4zLTQ3LjYtNDcuNi00Ny42DQoJCWMtMjYuMiwwLTQ3LjYsMjEuMy00Ny42LDQ3LjZjMCwyMi42LDE1LjgsNDEuNSwzNi45LDQ2LjN2MjcuM2MtMjguOCw1LjEtNTAuOCwzMC4yLTUwLjgsNjAuNWMwLDMwLjQsMjIuMiw1NS43LDUxLjIsNjAuNXYyOC44DQoJCWMtMjEuMyw0LjctMzcuNCwyMy43LTM3LjQsNDYuNGMwLDI2LjIsMjEuMyw0Ny42LDQ3LjYsNDcuNmMyNi4yLDAsNDcuNi0yMS4zLDQ3LjYtNDcuNmMwLTIyLjctMTYtNDEuOC0zNy40LTQ2LjR2LTI4LjgNCgkJYzE1LTIuNSwyOC4yLTEwLjQsMzcuNC0yMS44bDIyLjUsMTUuOWMtMS4yLDQuMy0xLjksOC43LTEuOSwxMy40YzAsMjYuMiwyMS4zLDQ3LjYsNDcuNiw0Ny42czQ3LjYtMjEuMyw0Ny42LTQ3LjYNCgkJQzM2Mi40LDI5MSwzNDEuMSwyNjkuNywzMTQuOCwyNjkuN3ogTTMxNC44LDE1OC40YzEyLjcsMCwyMy4xLDEwLjQsMjMuMSwyMy4xYzAsMTIuNy0xMC4zLDIzLjEtMjMuMSwyMy4xcy0yMy4xLTEwLjQtMjMuMS0yMy4xDQoJCUMyOTEuOCwxNjguOCwzMDIuMSwxNTguNCwzMTQuOCwxNTguNHogTTE3NiwxMTUuMWMwLTEyLjcsMTAuMy0yMy4xLDIzLjEtMjMuMWMxMi43LDAsMjMuMSwxMC40LDIzLjEsMjMuMQ0KCQljMCwxMi43LTEwLjMsMjMuMS0yMy4xLDIzLjFDMTg2LjMsMTM4LjIsMTc2LDEyNy44LDE3NiwxMTUuMXogTTIyMi4xLDM4NC45YzAsMTIuNy0xMC4zLDIzLjEtMjMuMSwyMy4xDQoJCWMtMTIuNywwLTIzLjEtMTAuNC0yMy4xLTIzLjFjMC0xMi43LDEwLjMtMjMuMSwyMy4xLTIzLjFDMjExLjgsMzYxLjgsMjIyLjEsMzcyLjIsMjIyLjEsMzg0Ljl6IE0xOTkuMSwyODEuMw0KCQljLTE3LjcsMC0zMi4yLTE0LjQtMzIuMi0zMi4yYzAtMTcuNywxNC40LTMyLjIsMzIuMi0zMi4yYzE3LjcsMCwzMi4yLDE0LjQsMzIuMiwzMi4yQzIzMS4yLDI2Ni45LDIxNi44LDI4MS4zLDE5OS4xLDI4MS4zeg0KCQkgTTMxNC44LDM0MC4zYy0xMi43LDAtMjMuMS0xMC40LTIzLjEtMjMuMWMwLTEyLjcsMTAuMy0yMy4xLDIzLjEtMjMuMXMyMy4xLDEwLjQsMjMuMSwyMy4xQzMzNy45LDMzMCwzMjcuNSwzNDAuMywzMTQuOCwzNDAuM3oiLz4NCjwvZz4NCjwvc3ZnPg0K"
+    camel.apache.org/provider: "Red Hat"
+    camel.apache.org/kamelet.group: "Kafka"
+    camel.apache.org/kamelet.namespace: "Kafka"
+  labels:
+    camel.apache.org/kamelet.type: "source"
+spec:
+  definition:
+    title: "Kafka Batch SSL Source"
+    description: |-
+      Receive data from Kafka topics in batch with SSL/TLS support and commit them manually through KafkaManualCommit or automatically.
+    required:
+      - topic
+      - bootstrapServers
+      - sslTruststoreLocation
+      - sslKeyPassword
+    type: object
+    properties:
+      topic:
+        title: Topic Names
+        description: Comma separated list of Kafka topic names
+        type: string
+        x-descriptors:
+          - urn:keda:metadata:topic
+          - urn:keda:required
+      bootstrapServers:
+        title: Bootstrap Servers
+        description: Comma separated list of Kafka Broker URLs
+        type: string
+        x-descriptors:
+          - urn:keda:metadata:bootstrapServers
+          - urn:keda:required
+      securityProtocol:
+        title: Security Protocol
+        description: Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT, SASL_SSL and SSL are supported
+        type: string
+        default: SSL
+      saslMechanism:
+        title: SASL Mechanism
+        description: The Simple Authentication and Security Layer (SASL) Mechanism used.
+        type: string
+        default: GSSAPI
+      autoCommitEnable:
+        title: Auto Commit Enable
+        description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
+        type: boolean
+        default: true
+      allowManualCommit:
+        title: Allow Manual Commit
+        description: Whether to allow doing manual commits
+        type: boolean
+        default: false
+      pollOnError:
+        title: Poll On Error Behavior
+        description: What to do if kafka threw an exception while polling for new messages. There are 5 enums and the value can be one of DISCARD, ERROR_HANDLER, RECONNECT, RETRY, STOP
+        type: string
+        default: "ERROR_HANDLER"
+      autoOffsetReset:
+        title: Auto Offset Reset
+        description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
+        type: string
+        default: "latest"
+        x-descriptors:
+          - urn:keda:metadata:offsetResetPolicy
+      consumerGroup:
+        title: Consumer Group
+        description: A string that uniquely identifies the group of consumers to which this source belongs
+        type: string
+        example: "my-group-id"
+        x-descriptors:
+          - urn:keda:metadata:consumerGroup
+          - urn:keda:required
+      deserializeHeaders:
+        title: Automatically Deserialize Headers
+        description: When enabled the Kamelet source will deserialize all message headers to String representation.
+        type: boolean
+        default: true
+      sslKeyPassword:
+        description: The password of the private key in the key store file.
+        title: SSL Key Password
+        type: string
+        format: password
+        x-descriptors:
+          - urn:camel:group:credentials
+          - urn:keda:authentication:password
+          - urn:keda:required
+      sslKeystorePassword:
+        description: The store password for the key store file.This is optional for client and only needed if ssl.keystore.location is configured.
+        title: SSL Keystore Password
+        type: string
+        format: password
+        x-descriptors:
+          - urn:camel:group:credentials
+          - urn:keda:authentication:password
+      sslEndpointAlgorithm:
+        description: The endpoint identification algorithm to validate server hostname using server certificate. Use none or false to disable server hostname verification.
+        title: SSL Endpoint Algorithm
+        type: string
+        default: https
+      sslProtocol:
+        description: The SSL protocol used to generate the SSLContext. Default setting is TLS, which is fine for most cases. Allowed values in recent JVMs are TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.
+        title: SSL Protocol
+        type: string
+        default: TLSv1.2
+      sslKeystoreLocation:
+        description: The location of the key store file. This is optional for client and can be used for two-way authentication for client.
+        title: SSL Keystore Location
+        type: string
+      sslTruststoreLocation:
+        description: The location of the trust store file.
+        title: SSL Truststore Location
+        type: string
+      sslEnabledProtocols:
+        description:   The list of protocols enabled for SSL connections. TLSv1.2, TLSv1.1 and TLSv1 are enabled by default.
+        title: SSL Enabled Protocols
+        type: string
+        default: TLSv1.2,TLSv1.1,TLSv1
+      saslJaasConfig:
+        description: Java Authentication and Authorization Service (JAAS) for Simple Authentication and Security Layer (SASL) configuration.
+        title: JAAS Configuration
+        type: string
+      batchSize:
+        title: Batch Dimension
+        description: The maximum number of records returned in a single call to poll()
+        type: int
+        default: 500
+      pollTimeout:
+        title: Poll Timeout Interval
+        description: The timeout used when polling the KafkaConsumer
+        type: int
+        default: 5000
+      maxPollIntervalMs:
+        title: Max Poll Interval
+        description: The maximum delay between invocations of poll() when using consumer group management
+        type: int
+      batchingIntervalMs:
+        title: Batching Interval
+        description: In consumer batching mode, then this option is specifying a time in millis, to trigger batch completion eager when the current batch size has not reached the maximum size defined by maxPollRecords. Notice the trigger is not exact at the given interval, as this can only happen between kafka polls (see pollTimeoutMs option).
+        type: int
+      topicIsPattern:
+        title: Topic Is Pattern
+        description: Whether the topic is a pattern (regular expression). This can be used to subscribe to dynamic number of topics matching the pattern.
+        type: boolean
+        default: false
+  dependencies:
+    - "camel:core"
+    - "camel:kafka"
+    - "camel:kamelet"
+  template:
+    beans:
+      - name: manualCommitFactory
+        type: "#class:org.apache.camel.component.kafka.consumer.DefaultKafkaManualCommitFactory"
+      - name: kafkaHeaderDeserializer
+        type: "#class:org.apache.camel.component.kafka.KafkaHeaderDeserializer"
+        properties:
+          enabled: '{{deserializeHeaders}}'
+    from:
+      uri: "kafka:{{topic}}"
+      parameters:
+        brokers: "{{bootstrapServers}}"
+        securityProtocol: "{{securityProtocol}}"
+        sslKeystoreLocation: "{{sslKeystoreLocation}}"
+        sslKeyPassword: "{{sslKeyPassword}}"
+        sslKeystorePassword: "{{sslKeystorePassword}}"
+        sslTruststoreLocation: "{{sslTruststoreLocation}}"
+        sslProtocol: "{{sslProtocol}}"
+        sslEnabledProtocols: "{{sslEnabledProtocols}}"
+        sslEndpointAlgorithm: "{{sslEndpointAlgorithm}}"
+        saslMechanism: "{{saslMechanism}}"
+        groupId: "{{?consumerGroup}}"
+        autoOffsetReset: "{{autoOffsetReset}}"
+        pollOnError: "{{pollOnError}}"
+        allowManualCommit: "{{allowManualCommit}}"
+        autoCommitEnable: "{{autoCommitEnable}}"
+        saslJaasConfig: "{{?saslJaasConfig}}"
+        maxPollRecords: "{{batchSize}}"
+        pollTimeoutMs: "{{pollTimeout}}"
+        maxPollIntervalMs: "{{?maxPollIntervalMs}}"
+        batchingIntervalMs: "{{?batchingIntervalMs}}"
+        batching: true
+        kafkaManualCommitFactory: "#bean:{{manualCommitFactory}}"
+        topicIsPattern: "{{topicIsPattern}}"
+      steps:
+        - process:
+            ref: "{{kafkaHeaderDeserializer}}"
+        - to: "kamelet:sink"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-sink.kamelet.yaml
@@ -122,24 +122,24 @@ spec:
           - simple: "${header[key]}"
             steps:
             - setHeader:
-                name: kafka.KEY
+                name: CamelKafkaKey
                 simple: "${header[key]}"
           - simple: "${header[ce-key]}"
             steps:
             - setHeader:
-                name: kafka.KEY
+                name: CamelKafkaKey
                 simple: "${header[ce-key]}"
       - choice:
           when:
           - simple: "${header[partition-key]}"
             steps:
             - setHeader:
-                name: kafka.PARTITION_KEY
+                name: CamelKafkaPartitionKey
                 simple: "${header[partition-key]}"
           - simple: "${header[ce-partitionkey]}"
             steps:
             - setHeader:
-                name: kafka.PARTITION_KEY
+                name: CamelKafkaPartitionKey
                 simple: "${header[ce-partitionkey]}"
       - to:
           uri: "kafka:{{topic}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-ssl-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-ssl-sink.kamelet.yaml
@@ -17,98 +17,114 @@
 apiVersion: camel.apache.org/v1
 kind: Kamelet
 metadata:
-  name: kafka-sink
+  name: kafka-ssl-sink
   annotations:
     camel.apache.org/kamelet.support.level: "Stable"
     camel.apache.org/catalog.version: "4.18.1-SNAPSHOT"
     camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxOS4wLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiDQoJIHZpZXdCb3g9IjAgMCA1MDAgNTAwIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MDAgNTAwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8ZyBpZD0iWE1MSURfMV8iPg0KCTxwYXRoIGlkPSJYTUxJRF85XyIgZD0iTTMxNC44LDI2OS43Yy0xNC4yLDAtMjcsNi4zLTM1LjcsMTYuMkwyNTYuOCwyNzBjMi40LTYuNSwzLjctMTMuNiwzLjctMjAuOWMwLTcuMi0xLjMtMTQuMS0zLjYtMjAuNg0KCQlsMjIuMy0xNS43YzguNyw5LjksMjEuNCwxNi4xLDM1LjYsMTYuMWMyNi4yLDAsNDcuNi0yMS4zLDQ3LjYtNDcuNnMtMjEuMy00Ny42LTQ3LjYtNDcuNnMtNDcuNiwyMS4zLTQ3LjYsNDcuNg0KCQljMCw0LjcsMC43LDkuMiwyLDEzLjVsLTIyLjMsMTUuN2MtOS4zLTExLjYtMjIuOC0xOS42LTM4LjEtMjIuMXYtMjYuOWMyMS42LTQuNSwzNy44LTIzLjcsMzcuOC00Ni42YzAtMjYuMi0yMS4zLTQ3LjYtNDcuNi00Ny42DQoJCWMtMjYuMiwwLTQ3LjYsMjEuMy00Ny42LDQ3LjZjMCwyMi42LDE1LjgsNDEuNSwzNi45LDQ2LjN2MjcuM2MtMjguOCw1LjEtNTAuOCwzMC4yLTUwLjgsNjAuNWMwLDMwLjQsMjIuMiw1NS43LDUxLjIsNjAuNXYyOC44DQoJCWMtMjEuMyw0LjctMzcuNCwyMy43LTM3LjQsNDYuNGMwLDI2LjIsMjEuMyw0Ny42LDQ3LjYsNDcuNmMyNi4yLDAsNDcuNi0yMS4zLDQ3LjYtNDcuNmMwLTIyLjctMTYtNDEuOC0zNy40LTQ2LjR2LTI4LjgNCgkJYzE1LTIuNSwyOC4yLTEwLjQsMzcuNC0yMS44bDIyLjUsMTUuOWMtMS4yLDQuMy0xLjksOC43LTEuOSwxMy40YzAsMjYuMiwyMS4zLDQ3LjYsNDcuNiw0Ny42czQ3LjYtMjEuMyw0Ny42LTQ3LjYNCgkJQzM2Mi40LDI5MSwzNDEuMSwyNjkuNywzMTQuOCwyNjkuN3ogTTMxNC44LDE1OC40YzEyLjcsMCwyMy4xLDEwLjQsMjMuMSwyMy4xYzAsMTIuNy0xMC4zLDIzLjEtMjMuMSwyMy4xcy0yMy4xLTEwLjQtMjMuMS0yMy4xDQoJCUMyOTEuOCwxNjguOCwzMDIuMSwxNTguNCwzMTQuOCwxNTguNHogTTE3NiwxMTUuMWMwLTEyLjcsMTAuMy0yMy4xLDIzLjEtMjMuMWMxMi43LDAsMjMuMSwxMC40LDIzLjEsMjMuMQ0KCQljMCwxMi43LTEwLjMsMjMuMS0yMy4xLDIzLjFDMTg2LjMsMTM4LjIsMTc2LDEyNy44LDE3NiwxMTUuMXogTTIyMi4xLDM4NC45YzAsMTIuNy0xMC4zLDIzLjEtMjMuMSwyMy4xDQoJCWMtMTIuNywwLTIzLjEtMTAuNC0yMy4xLTIzLjFjMC0xMi43LDEwLjMtMjMuMSwyMy4xLTIzLjFDMjExLjgsMzYxLjgsMjIyLjEsMzcyLjIsMjIyLjEsMzg0Ljl6IE0xOTkuMSwyODEuMw0KCQljLTE3LjcsMC0zMi4yLTE0LjQtMzIuMi0zMi4yYzAtMTcuNywxNC40LTMyLjIsMzIuMi0zMi4yYzE3LjcsMCwzMi4yLDE0LjQsMzIuMiwzMi4yQzIzMS4yLDI2Ni45LDIxNi44LDI4MS4zLDE5OS4xLDI4MS4zeg0KCQkgTTMxNC44LDM0MC4zYy0xMi43LDAtMjMuMS0xMC40LTIzLjEtMjMuMWMwLTEyLjcsMTAuMy0yMy4xLDIzLjEtMjMuMXMyMy4xLDEwLjQsMjMuMSwyMy4xQzMzNy45LDMzMCwzMjcuNSwzNDAuMywzMTQuOCwzNDAuM3oiLz4NCjwvZz4NCjwvc3ZnPg0K"
-    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/provider: "Red Hat"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
   labels:
     camel.apache.org/kamelet.type: "sink"
 spec:
   definition:
-    title: "Kafka Sink"
-    description: Send data to Kafka topics.
+    description: |-
+      Send data to Kafka topics wit TLS/SSL support.
+
+      The Kamelet is able to understand the following headers to be set:
+
+      - `key` / `ce-key`: as message key
+
+      - `partition-key` / `ce-partitionkey`: as message partition key
+
+      Both the headers are optional.
     required:
       - topic
       - bootstrapServers
-    type: object
+      - sslKeystoreLocation
+      - sslKeystorePassword
+      - sslTruststoreLocation
+      - sslTruststorePassword
+      - sslKeyPassword
     properties:
-      topic:
-        title: Topic Names
-        description: Comma separated list of Kafka topic names
-        type: string
       bootstrapServers:
-        title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
+        title: Brokers
         type: string
-      saslAuthType:
-        title: Authentication Type
-        description: Authentication type to use. Use NONE for no authentication, PLAIN or SCRAM_SHA_256/SCRAM_SHA_512 for username/password, SSL for certificate-based, OAUTH for OAuth 2.0, AWS_MSK_IAM for MSK, or KERBEROS for Kerberos.
-        type: string
-        default: NONE
-        enum: ["NONE", "PLAIN", "SCRAM_SHA_256", "SCRAM_SHA_512", "SSL", "OAUTH", "AWS_MSK_IAM", "KERBEROS"]
-      saslUsername:
-        title: Username
-        description: Username for SASL authentication. Required when saslAuthType is PLAIN, SCRAM_SHA_256, or SCRAM_SHA_512.
-        type: string
-        x-descriptors:
-          - urn:camel:group:credentials
-      saslPassword:
-        title: Password
-        description: Password for SASL authentication. Required when saslAuthType is PLAIN, SCRAM_SHA_256, or SCRAM_SHA_512.
-        type: string
-        format: password
-        x-descriptors:
-          - urn:camel:group:credentials
-      oauthClientId:
-        title: OAuth Client ID
-        description: OAuth client ID. Required when saslAuthType is OAUTH.
-        type: string
-      oauthClientSecret:
-        title: OAuth Client Secret
-        description: OAuth client secret. Required when saslAuthType is OAUTH.
-        type: string
-        format: password
-        x-descriptors:
-          - urn:camel:group:credentials
-      oauthTokenEndpointUri:
-        title: OAuth Token Endpoint
-        description: OAuth token endpoint URI. Required when saslAuthType is OAUTH.
-        type: string
-      oauthScope:
-        title: OAuth Scope
-        description: OAuth scope. Optional when saslAuthType is OAUTH.
-        type: string
-      sslTruststoreLocation:
-        title: SSL Truststore Location
-        description: The location of the trust store file.
-        type: string
-      sslTruststorePassword:
-        title: SSL Truststore Password
-        description: The password for the trust store file.
-        type: string
-        format: password
-        x-descriptors:
-          - urn:camel:group:credentials
       sslKeystoreLocation:
+        description: >-
+          The location of the key store file. This is optional for client and
+          can be used for two-way authentication for client.
         title: SSL Keystore Location
-        description: The location of the key store file. Used for mTLS authentication.
+        type: string
+      sslProtocol:
+        default: TLSv1.2
+        description: >-
+          The SSL protocol used to generate the SSLContext. Default setting is
+          TLS, which is fine for most cases. Allowed values in recent JVMs are
+          TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 may be supported in
+          older JVMs, but their usage is discouraged due to known security
+          vulnerabilities.
+        title: SSL Protocol
+        type: string
+      saslMechanism:
+        title: SASL Mechanism
+        description: The Simple Authentication and Security Layer (SASL) Mechanism used.
+        type: string
+        default: GSSAPI
+      sslEnabledProtocols:
+        default: TLSv1.2,TLSv1.1,TLSv1
+        description: >-
+          The list of protocols enabled for SSL connections. TLSv1.2, TLSv1.1
+          and TLSv1 are enabled by default.
+        title: SSL Enabled Protocols
         type: string
       sslKeystorePassword:
+        description: >-
+          The store password for the key store file.This is optional for client
+          and only needed if ssl.keystore.location is configured.
         title: SSL Keystore Password
-        description: The password for the key store file.
+        type: string
+        format: password
+        x-descriptors:
+          - urn:camel:group:credentials
+      sslTruststoreLocation:
+        description: The location of the trust store file.
+        title: SSL Truststore Location
+        type: string
+      sslTruststorePassword:
+        description: The store password for the trust store file.
+        title: SSL Truststore Password
         type: string
         format: password
         x-descriptors:
           - urn:camel:group:credentials
       sslKeyPassword:
-        title: SSL Key Password
         description: The password of the private key in the key store file.
+        title: SSL Key Password
         type: string
         format: password
+        x-descriptors:
+          - urn:camel:group:credentials
+      sslEndpointAlgorithm:
+        description: The endpoint identification algorithm to validate server hostname using server certificate. Use none or false to disable server hostname verification.
+        title: SSL Endpoint Algorithm
+        type: string
+        default: https
+      topic:
+        description: Comma separated list of Kafka topic names
+        title: Topic Names
+        type: string
+      securityProtocol:
+        default: SSL
+        description: >-
+          Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT,
+          SASL_SSL and SSL are supported
+        title: Security Protocol
+        type: string
+    title: Kafka SSL Sink
+    type: object
   dependencies:
     - "camel:core"
     - "camel:kafka"
@@ -117,43 +133,41 @@ spec:
     from:
       uri: "kamelet:source"
       steps:
-      - choice:
-          when:
-          - simple: "${header[key]}"
-            steps:
-            - setHeader:
-                name: CamelKafkaKey
-                simple: "${header[key]}"
-          - simple: "${header[ce-key]}"
-            steps:
-            - setHeader:
-                name: CamelKafkaKey
-                simple: "${header[ce-key]}"
-      - choice:
-          when:
-          - simple: "${header[partition-key]}"
-            steps:
-            - setHeader:
-                name: CamelKafkaPartitionKey
-                simple: "${header[partition-key]}"
-          - simple: "${header[ce-partitionkey]}"
-            steps:
-            - setHeader:
-                name: CamelKafkaPartitionKey
-                simple: "${header[ce-partitionkey]}"
-      - to:
-          uri: "kafka:{{topic}}"
-          parameters:
-            brokers: "{{bootstrapServers}}"
-            saslAuthType: "{{saslAuthType}}"
-            saslUsername: "{{?saslUsername}}"
-            saslPassword: "{{?saslPassword}}"
-            oauthClientId: "{{?oauthClientId}}"
-            oauthClientSecret: "{{?oauthClientSecret}}"
-            oauthTokenEndpointUri: "{{?oauthTokenEndpointUri}}"
-            oauthScope: "{{?oauthScope}}"
-            sslTruststoreLocation: "{{?sslTruststoreLocation}}"
-            sslTruststorePassword: "{{?sslTruststorePassword}}"
-            sslKeystoreLocation: "{{?sslKeystoreLocation}}"
-            sslKeystorePassword: "{{?sslKeystorePassword}}"
-            sslKeyPassword: "{{?sslKeyPassword}}"
+        - choice:
+            when:
+              - simple: ${header[key]}
+                steps:
+                  - setHeader:
+                      name: CamelKafkaKey
+                      simple: ${header[key]}
+              - simple: ${header[ce-key]}
+                steps:
+                  - setHeader:
+                      name: CamelKafkaKey
+                      simple: ${header[ce-key]}
+        - choice:
+            when:
+              - simple: ${header[partition-key]}
+                steps:
+                  - setHeader:
+                      name: CamelKafkaPartitionKey
+                      simple: ${header[partition-key]}
+              - simple: ${header[ce-partitionkey]}
+                steps:
+                  - setHeader:
+                      name: CamelKafkaPartitionKey
+                      simple: ${header[ce-partitionkey]}
+        - to:
+            uri: "kafka:{{topic}}"
+            parameters:
+              brokers: "{{bootstrapServers}}"
+              securityProtocol: "{{securityProtocol}}"
+              sslKeystoreLocation: "{{sslKeystoreLocation}}"
+              sslKeyPassword: "{{sslKeyPassword}}"
+              sslKeystorePassword: "{{sslKeystorePassword}}"
+              sslTruststoreLocation: "{{sslTruststoreLocation}}"
+              sslTruststorePassword: "{{sslTruststorePassword}}"
+              sslProtocol: "{{sslProtocol}}"
+              sslEnabledProtocols: "{{sslEnabledProtocols}}"
+              sslEndpointAlgorithm: "{{sslEndpointAlgorithm}}"
+              saslMechanism: "{{saslMechanism}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-ssl-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-ssl-source.kamelet.yaml
@@ -1,0 +1,193 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: kafka-ssl-source
+  annotations:
+    camel.apache.org/kamelet.support.level: "Stable"
+    camel.apache.org/catalog.version: "4.18.1-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxOS4wLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiDQoJIHZpZXdCb3g9IjAgMCA1MDAgNTAwIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MDAgNTAwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8ZyBpZD0iWE1MSURfMV8iPg0KCTxwYXRoIGlkPSJYTUxJRF85XyIgZD0iTTMxNC44LDI2OS43Yy0xNC4yLDAtMjcsNi4zLTM1LjcsMTYuMkwyNTYuOCwyNzBjMi40LTYuNSwzLjctMTMuNiwzLjctMjAuOWMwLTcuMi0xLjMtMTQuMS0zLjYtMjAuNg0KCQlsMjIuMy0xNS43YzguNyw5LjksMjEuNCwxNi4xLDM1LjYsMTYuMWMyNi4yLDAsNDcuNi0yMS4zLDQ3LjYtNDcuNnMtMjEuMy00Ny42LTQ3LjYtNDcuNnMtNDcuNiwyMS4zLTQ3LjYsNDcuNg0KCQljMCw0LjcsMC43LDkuMiwyLDEzLjVsLTIyLjMsMTUuN2MtOS4zLTExLjYtMjIuOC0xOS42LTM4LjEtMjIuMXYtMjYuOWMyMS42LTQuNSwzNy44LTIzLjcsMzcuOC00Ni42YzAtMjYuMi0yMS4zLTQ3LjYtNDcuNi00Ny42DQoJCWMtMjYuMiwwLTQ3LjYsMjEuMy00Ny42LDQ3LjZjMCwyMi42LDE1LjgsNDEuNSwzNi45LDQ2LjN2MjcuM2MtMjguOCw1LjEtNTAuOCwzMC4yLTUwLjgsNjAuNWMwLDMwLjQsMjIuMiw1NS43LDUxLjIsNjAuNXYyOC44DQoJCWMtMjEuMyw0LjctMzcuNCwyMy43LTM3LjQsNDYuNGMwLDI2LjIsMjEuMyw0Ny42LDQ3LjYsNDcuNmMyNi4yLDAsNDcuNi0yMS4zLDQ3LjYtNDcuNmMwLTIyLjctMTYtNDEuOC0zNy40LTQ2LjR2LTI4LjgNCgkJYzE1LTIuNSwyOC4yLTEwLjQsMzcuNC0yMS44bDIyLjUsMTUuOWMtMS4yLDQuMy0xLjksOC43LTEuOSwxMy40YzAsMjYuMiwyMS4zLDQ3LjYsNDcuNiw0Ny42czQ3LjYtMjEuMyw0Ny42LTQ3LjYNCgkJQzM2Mi40LDI5MSwzNDEuMSwyNjkuNywzMTQuOCwyNjkuN3ogTTMxNC44LDE1OC40YzEyLjcsMCwyMy4xLDEwLjQsMjMuMSwyMy4xYzAsMTIuNy0xMC4zLDIzLjEtMjMuMSwyMy4xcy0yMy4xLTEwLjQtMjMuMS0yMy4xDQoJCUMyOTEuOCwxNjguOCwzMDIuMSwxNTguNCwzMTQuOCwxNTguNHogTTE3NiwxMTUuMWMwLTEyLjcsMTAuMy0yMy4xLDIzLjEtMjMuMWMxMi43LDAsMjMuMSwxMC40LDIzLjEsMjMuMQ0KCQljMCwxMi43LTEwLjMsMjMuMS0yMy4xLDIzLjFDMTg2LjMsMTM4LjIsMTc2LDEyNy44LDE3NiwxMTUuMXogTTIyMi4xLDM4NC45YzAsMTIuNy0xMC4zLDIzLjEtMjMuMSwyMy4xDQoJCWMtMTIuNywwLTIzLjEtMTAuNC0yMy4xLTIzLjFjMC0xMi43LDEwLjMtMjMuMSwyMy4xLTIzLjFDMjExLjgsMzYxLjgsMjIyLjEsMzcyLjIsMjIyLjEsMzg0Ljl6IE0xOTkuMSwyODEuMw0KCQljLTE3LjcsMC0zMi4yLTE0LjQtMzIuMi0zMi4yYzAtMTcuNywxNC40LTMyLjIsMzIuMi0zMi4yYzE3LjcsMCwzMi4yLDE0LjQsMzIuMiwzMi4yQzIzMS4yLDI2Ni45LDIxNi44LDI4MS4zLDE5OS4xLDI4MS4zeg0KCQkgTTMxNC44LDM0MC4zYy0xMi43LDAtMjMuMS0xMC40LTIzLjEtMjMuMWMwLTEyLjcsMTAuMy0yMy4xLDIzLjEtMjMuMXMyMy4xLDEwLjQsMjMuMSwyMy4xQzMzNy45LDMzMCwzMjcuNSwzNDAuMywzMTQuOCwzNDAuM3oiLz4NCjwvZz4NCjwvc3ZnPg0K"
+    camel.apache.org/provider: "Red Hat"
+    camel.apache.org/kamelet.group: "Kafka"
+    camel.apache.org/kamelet.namespace: "Kafka"
+  labels:
+    camel.apache.org/kamelet.type: "source"
+spec:
+  definition:
+    title: "Kafka SSL Source"
+    description: |-
+      Receive data from Kafka topics with SSL/TLS support
+    required:
+      - topic
+      - bootstrapServers
+      - sslTruststoreLocation
+      - sslTruststorePassword
+      - sslKeyPassword
+    type: object
+    properties:
+      topic:
+        title: Topic Names
+        description: Comma separated list of Kafka topic names
+        type: string
+        x-descriptors:
+          - urn:keda:metadata:topic
+          - urn:keda:required
+      bootstrapServers:
+        title: Bootstrap Servers
+        description: Comma separated list of Kafka Broker URLs
+        type: string
+        x-descriptors:
+          - urn:keda:metadata:bootstrapServers
+          - urn:keda:required
+      securityProtocol:
+        title: Security Protocol
+        description: Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT, SASL_SSL and SSL are supported
+        type: string
+        default: SSL
+      saslMechanism:
+        title: SASL Mechanism
+        description: The Simple Authentication and Security Layer (SASL) Mechanism used.
+        type: string
+        default: GSSAPI
+      autoCommitEnable:
+        title: Auto Commit Enable
+        description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
+        type: boolean
+        default: true
+      allowManualCommit:
+        title: Allow Manual Commit
+        description: Whether to allow doing manual commits
+        type: boolean
+        default: false
+      pollOnError:
+        title: Poll On Error Behavior
+        description: What to do if kafka threw an exception while polling for new messages. There are 5 enums and the value can be one of DISCARD, ERROR_HANDLER, RECONNECT, RETRY, STOP
+        type: string
+        default: "ERROR_HANDLER"
+      autoOffsetReset:
+        title: Auto Offset Reset
+        description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
+        type: string
+        default: "latest"
+        x-descriptors:
+          - urn:keda:metadata:offsetResetPolicy
+      consumerGroup:
+        title: Consumer Group
+        description: A string that uniquely identifies the group of consumers to which this source belongs
+        type: string
+        example: "my-group-id"
+        x-descriptors:
+          - urn:keda:metadata:consumerGroup
+          - urn:keda:required
+      deserializeHeaders:
+        title: Automatically Deserialize Headers
+        description: When enabled the Kamelet source will deserialize all message headers to String representation.
+        type: boolean
+        default: true
+      sslKeyPassword:
+        description: The password of the private key in the key store file.
+        title: SSL Key Password
+        type: string
+        format: password
+        x-descriptors:
+          - urn:camel:group:credentials
+          - urn:keda:authentication:password
+          - urn:keda:required
+      sslKeystorePassword:
+        description: The store password for the key store file.This is optional for client and only needed if ssl.keystore.location is configured.
+        title: SSL Keystore Password
+        type: string
+        format: password
+        x-descriptors:
+          - urn:camel:group:credentials
+          - urn:keda:authentication:password
+      sslEndpointAlgorithm:
+        description: The endpoint identification algorithm to validate server hostname using server certificate. Use none or false to disable server hostname verification.
+        title: SSL Endpoint Algorithm
+        type: string
+        default: https
+      sslProtocol:
+        description: The SSL protocol used to generate the SSLContext. Default setting is TLS, which is fine for most cases. Allowed values in recent JVMs are TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.
+        title: SSL Protocol
+        type: string
+        default: TLSv1.2
+      sslKeystoreLocation:
+        description: The location of the key store file. This is optional for client and can be used for two-way authentication for client.
+        title: SSL Keystore Location
+        type: string
+      sslTruststoreLocation:
+        description: The location of the trust store file.
+        title: SSL Truststore Location
+        type: string
+      sslTruststorePassword:
+        description: The store password for the trust store file.
+        title: SSL Truststore Password
+        type: string
+        format: password
+        x-descriptors:
+          - urn:camel:group:credentials
+          - urn:keda:authentication:password
+      sslEnabledProtocols:
+        description:   The list of protocols enabled for SSL connections. TLSv1.2, TLSv1.1 and TLSv1 are enabled by default.
+        title: SSL Enabled Protocols
+        type: string
+        default: TLSv1.2,TLSv1.1,TLSv1
+      saslJaasConfig:
+        description: Java Authentication and Authorization Service (JAAS) for Simple Authentication and Security Layer (SASL) configuration.
+        title: JAAS Configuration
+        type: string
+      topicIsPattern:
+        title: Topic Is Pattern
+        description: Whether the topic is a pattern (regular expression). This can be used to subscribe to dynamic number of topics matching the pattern.
+        type: boolean
+        default: false
+  dependencies:
+    - "camel:core"
+    - "camel:kafka"
+    - "camel:kamelet"
+  template:
+    beans:
+      - name: kafkaHeaderDeserializer
+        type: "#class:org.apache.camel.component.kafka.KafkaHeaderDeserializer"
+        properties:
+          enabled: '{{deserializeHeaders}}'
+    from:
+      uri: "kafka:{{topic}}"
+      parameters:
+        brokers: "{{bootstrapServers}}"
+        securityProtocol: "{{securityProtocol}}"
+        sslKeystoreLocation: "{{sslKeystoreLocation}}"
+        sslKeyPassword: "{{sslKeyPassword}}"
+        sslKeystorePassword: "{{sslKeystorePassword}}"
+        sslTruststoreLocation: "{{sslTruststoreLocation}}"
+        sslTruststorePassword: "{{sslTruststorePassword}}"
+        sslProtocol: "{{sslProtocol}}"
+        sslEnabledProtocols: "{{sslEnabledProtocols}}"
+        sslEndpointAlgorithm: "{{sslEndpointAlgorithm}}"
+        saslMechanism: "{{saslMechanism}}"
+        groupId: "{{?consumerGroup}}"
+        autoOffsetReset: "{{autoOffsetReset}}"
+        pollOnError: "{{pollOnError}}"
+        allowManualCommit: "{{allowManualCommit}}"
+        autoCommitEnable: "{{autoCommitEnable}}"
+        saslJaasConfig: "{{?saslJaasConfig}}"
+        topicIsPattern: "{{topicIsPattern}}"
+      steps:
+        - process:
+            ref: "{{kafkaHeaderDeserializer}}"
+        - to: "kamelet:sink"


### PR DESCRIPTION
## Summary
- Fix `configuration` endpoint parameter validation failure in `kafka-batch-ssl-source`, `kafka-ssl-source`, and `kafka-ssl-sink` kamelets by passing Kafka properties as direct endpoint parameters instead of via a `KafkaConfiguration` bean
- Fix CAMEL-23584 header rename in `kafka-ssl-sink` and `kafka-sink` kamelets (`kafka.KEY` → `CamelKafkaKey`, `kafka.PARTITION_KEY` → `CamelKafkaPartitionKey`)

## Test plan
- [x] Build passes with `mvn verify`