### PR TITLE
Fix salesforce and jira kamelets for header renames

### DIFF
--- a/kamelets/jira-add-comment-sink.kamelet.yaml
+++ b/kamelets/jira-add-comment-sink.kamelet.yaml
@@ -78,7 +78,7 @@ spec:
           - simple: "${header[ce-issueKey]}"
             steps:
             - setHeader:
-                name: issueKey
+                name: CamelJiraIssueKey
                 simple: "${header[ce-issueKey]}"
       - to:
           uri: "jira:AddComment"

--- a/kamelets/jira-add-issue-sink.kamelet.yaml
+++ b/kamelets/jira-add-issue-sink.kamelet.yaml
@@ -78,42 +78,42 @@ spec:
           - simple: "${header[ce-projectKey]}"
             steps:
             - setHeader:
-                name: projectKey
+                name: CamelJiraIssueProjectKey
                 simple: "${header[ce-projectKey]}"
       - choice:
           when:
           - simple: "${header[ce-issueTypeName]}"
             steps:
             - setHeader:
-                name: issueTypeName
+                name: CamelJiraIssueTypeName
                 simple: "${header[ce-issueTypeName]}"
       - choice:
           when:
           - simple: "${header[ce-issueSummary]}"
             steps:
             - setHeader:
-                name: issueSummary
+                name: CamelJiraIssueSummary
                 simple: "${header[ce-issueSummary]}"
       - choice:
           when:
           - simple: "${header[ce-issueAssignee]}"
             steps:
             - setHeader:
-                name: issueAssignee
+                name: CamelJiraIssueAssignee
                 simple: "${header[ce-issueAssignee]}"
       - choice:
           when:
           - simple: "${header[ce-issuePriorityName]}"
             steps:
             - setHeader:
-                name: issuePriorityName
+                name: CamelJiraIssuePriorityName
                 simple: "${header[ce-issuePriorityName]}"
       - choice:
           when:
           - simple: "${header[ce-issueComponents]}"
             steps:
             - setHeader:
-                name: issueComponents
+                name: CamelJiraIssueComponents
                 simple: "${header[ce-issueComponents]}"
       - choice:
           when:

--- a/kamelets/jira-transition-issue-sink.kamelet.yaml
+++ b/kamelets/jira-transition-issue-sink.kamelet.yaml
@@ -78,14 +78,14 @@ spec:
           - simple: "${header[ce-issueKey]}"
             steps:
             - setHeader:
-                name: issueKey
+                name: CamelJiraIssueKey
                 simple: "${header[ce-issueKey]}"
       - choice:
           when:
           - simple: "${header[ce-issueTransitionId]}"
             steps:
             - setHeader:
-                name: issueTransitionId
+                name: CamelJiraIssueTransitionId
                 simple: "${header[ce-issueTransitionId]}"
       - to:
           uri: "jira:transitionIssue"

--- a/kamelets/jira-update-issue-sink.kamelet.yaml
+++ b/kamelets/jira-update-issue-sink.kamelet.yaml
@@ -78,42 +78,42 @@ spec:
           - simple: "${header[ce-issueKey]}"
             steps:
             - setHeader:
-                name: issueKey
+                name: CamelJiraIssueKey
                 simple: "${header[ce-issueKey]}"
       - choice:
           when:
           - simple: "${header[ce-issueTypeName]}"
             steps:
             - setHeader:
-                name: issueTypeName
+                name: CamelJiraIssueTypeName
                 simple: "${header[ce-issueTypeName]}"
       - choice:
           when:
           - simple: "${header[ce-issueSummary]}"
             steps:
             - setHeader:
-                name: issueSummary
+                name: CamelJiraIssueSummary
                 simple: "${header[ce-issueSummary]}"
       - choice:
           when:
           - simple: "${header[ce-issueAssignee]}"
             steps:
             - setHeader:
-                name: issueAssignee
+                name: CamelJiraIssueAssignee
                 simple: "${header[ce-issueAssignee]}"
       - choice:
           when:
           - simple: "${header[ce-issuePriorityName]}"
             steps:
             - setHeader:
-                name: issuePriorityName
+                name: CamelJiraIssuePriorityName
                 simple: "${header[ce-issuePriorityName]}"
       - choice:
           when:
           - simple: "${header[ce-issueComponents]}"
             steps:
             - setHeader:
-                name: issueComponents
+                name: CamelJiraIssueComponents
                 simple: "${header[ce-issueComponents]}"
       - choice:
           when:

--- a/kamelets/salesforce-delete-sink.kamelet.yaml
+++ b/kamelets/salesforce-delete-sink.kamelet.yaml
@@ -99,16 +99,16 @@ spec:
       uri: kamelet:source
       steps:
         - setHeader:
-            name: sObjectId
+            name: CamelSalesforceSObjectId
             jsonpath: "$['sObjectId']"
         - setHeader:
-            name: sObjectName
+            name: CamelSalesforceSObjectName
             jsonpath: "$['sObjectName']"
         - setBody:
             simple: "${null}"
         - to:
             uri: "{{local-delete-salesforce}}:deleteSObject"
         - removeHeader:
-            name: sObjectId
+            name: CamelSalesforceSObjectId
         - removeHeader:
-            name: sObjectName
+            name: CamelSalesforceSObjectName

--- a/kamelets/salesforce-update-sink.kamelet.yaml
+++ b/kamelets/salesforce-update-sink.kamelet.yaml
@@ -93,10 +93,10 @@ spec:
       uri: kamelet:source
       steps:
         - setHeader:
-            name: sObjectId
+            name: CamelSalesforceSObjectId
             jsonpath: "$.sObjectId"
         - setHeader:
-            name: sObjectName
+            name: CamelSalesforceSObjectName
             jsonpath: "$.sObjectName"
         - transform:
             jsonpath: "$.payload"
@@ -107,6 +107,6 @@ spec:
             parameters:
               rawPayload: "true"
         - removeHeader:
-            name: sObjectId
+            name: CamelSalesforceSObjectId
         - removeHeader:
-            name: sObjectName
+            name: CamelSalesforceSObjectName

--- a/library/camel-kamelets/src/main/resources/kamelets/jira-add-comment-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jira-add-comment-sink.kamelet.yaml
@@ -78,7 +78,7 @@ spec:
           - simple: "${header[ce-issueKey]}"
             steps:
             - setHeader:
-                name: issueKey
+                name: CamelJiraIssueKey
                 simple: "${header[ce-issueKey]}"
       - to:
           uri: "jira:AddComment"

--- a/library/camel-kamelets/src/main/resources/kamelets/jira-add-issue-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jira-add-issue-sink.kamelet.yaml
@@ -78,42 +78,42 @@ spec:
           - simple: "${header[ce-projectKey]}"
             steps:
             - setHeader:
-                name: projectKey
+                name: CamelJiraIssueProjectKey
                 simple: "${header[ce-projectKey]}"
       - choice:
           when:
           - simple: "${header[ce-issueTypeName]}"
             steps:
             - setHeader:
-                name: issueTypeName
+                name: CamelJiraIssueTypeName
                 simple: "${header[ce-issueTypeName]}"
       - choice:
           when:
           - simple: "${header[ce-issueSummary]}"
             steps:
             - setHeader:
-                name: issueSummary
+                name: CamelJiraIssueSummary
                 simple: "${header[ce-issueSummary]}"
       - choice:
           when:
           - simple: "${header[ce-issueAssignee]}"
             steps:
             - setHeader:
-                name: issueAssignee
+                name: CamelJiraIssueAssignee
                 simple: "${header[ce-issueAssignee]}"
       - choice:
           when:
           - simple: "${header[ce-issuePriorityName]}"
             steps:
             - setHeader:
-                name: issuePriorityName
+                name: CamelJiraIssuePriorityName
                 simple: "${header[ce-issuePriorityName]}"
       - choice:
           when:
           - simple: "${header[ce-issueComponents]}"
             steps:
             - setHeader:
-                name: issueComponents
+                name: CamelJiraIssueComponents
                 simple: "${header[ce-issueComponents]}"
       - choice:
           when:

--- a/library/camel-kamelets/src/main/resources/kamelets/jira-transition-issue-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jira-transition-issue-sink.kamelet.yaml
@@ -78,14 +78,14 @@ spec:
           - simple: "${header[ce-issueKey]}"
             steps:
             - setHeader:
-                name: issueKey
+                name: CamelJiraIssueKey
                 simple: "${header[ce-issueKey]}"
       - choice:
           when:
           - simple: "${header[ce-issueTransitionId]}"
             steps:
             - setHeader:
-                name: issueTransitionId
+                name: CamelJiraIssueTransitionId
                 simple: "${header[ce-issueTransitionId]}"
       - to:
           uri: "jira:transitionIssue"

--- a/library/camel-kamelets/src/main/resources/kamelets/jira-update-issue-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jira-update-issue-sink.kamelet.yaml
@@ -78,42 +78,42 @@ spec:
           - simple: "${header[ce-issueKey]}"
             steps:
             - setHeader:
-                name: issueKey
+                name: CamelJiraIssueKey
                 simple: "${header[ce-issueKey]}"
       - choice:
           when:
           - simple: "${header[ce-issueTypeName]}"
             steps:
             - setHeader:
-                name: issueTypeName
+                name: CamelJiraIssueTypeName
                 simple: "${header[ce-issueTypeName]}"
       - choice:
           when:
           - simple: "${header[ce-issueSummary]}"
             steps:
             - setHeader:
-                name: issueSummary
+                name: CamelJiraIssueSummary
                 simple: "${header[ce-issueSummary]}"
       - choice:
           when:
           - simple: "${header[ce-issueAssignee]}"
             steps:
             - setHeader:
-                name: issueAssignee
+                name: CamelJiraIssueAssignee
                 simple: "${header[ce-issueAssignee]}"
       - choice:
           when:
           - simple: "${header[ce-issuePriorityName]}"
             steps:
             - setHeader:
-                name: issuePriorityName
+                name: CamelJiraIssuePriorityName
                 simple: "${header[ce-issuePriorityName]}"
       - choice:
           when:
           - simple: "${header[ce-issueComponents]}"
             steps:
             - setHeader:
-                name: issueComponents
+                name: CamelJiraIssueComponents
                 simple: "${header[ce-issueComponents]}"
       - choice:
           when:

--- a/library/camel-kamelets/src/main/resources/kamelets/salesforce-delete-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/salesforce-delete-sink.kamelet.yaml
@@ -99,16 +99,16 @@ spec:
       uri: kamelet:source
       steps:
         - setHeader:
-            name: sObjectId
+            name: CamelSalesforceSObjectId
             jsonpath: "$['sObjectId']"
         - setHeader:
-            name: sObjectName
+            name: CamelSalesforceSObjectName
             jsonpath: "$['sObjectName']"
         - setBody:
             simple: "${null}"
         - to:
             uri: "{{local-delete-salesforce}}:deleteSObject"
         - removeHeader:
-            name: sObjectId
+            name: CamelSalesforceSObjectId
         - removeHeader:
-            name: sObjectName
+            name: CamelSalesforceSObjectName

--- a/library/camel-kamelets/src/main/resources/kamelets/salesforce-update-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/salesforce-update-sink.kamelet.yaml
@@ -93,10 +93,10 @@ spec:
       uri: kamelet:source
       steps:
         - setHeader:
-            name: sObjectId
+            name: CamelSalesforceSObjectId
             jsonpath: "$.sObjectId"
         - setHeader:
-            name: sObjectName
+            name: CamelSalesforceSObjectName
             jsonpath: "$.sObjectName"
         - transform:
             jsonpath: "$.payload"
@@ -107,6 +107,6 @@ spec:
             parameters:
               rawPayload: "true"
         - removeHeader:
-            name: sObjectId
+            name: CamelSalesforceSObjectId
         - removeHeader:
-            name: sObjectName
+            name: CamelSalesforceSObjectName


### PR DESCRIPTION
## Summary
- Update salesforce-delete-sink and salesforce-update-sink kamelets to use `CamelSalesforceSObjectId` / `CamelSalesforceSObjectName` headers (CAMEL-23716)
- Update jira-add-comment-sink, jira-add-issue-sink, jira-update-issue-sink, and jira-transition-issue-sink kamelets to use `CamelJira*` headers (CAMEL-23576)

Both salesforce and jira components had their Exchange header constant string values renamed to follow the `Camel<Component>*` convention on camel-4.18.x (CAMEL-23577). The kamelets were still setting headers using the old literal names, causing the component producers to not find them.

Fixes CSB-9719 (salesforce) and prevents the same regression for jira kamelets.

## Test plan
- [ ] Verify `SalesforceDeleteSinkKameletITCase` and `SalesforceUpdateSinkKameletITCase` pass against CS7
- [ ] Verify jira kamelet sink tests pass against CS7